### PR TITLE
[refactor] Remove helpers from data model

### DIFF
--- a/lib/models/functions.js
+++ b/lib/models/functions.js
@@ -53,10 +53,4 @@ class Method extends BaseFunction {
   }
 }
 
-class Helper extends Function {
-  static detect(doc) {
-    return super.detect(doc) && doc.file.match(/helpers\//) !== null;
-  }
-}
-
-module.exports = { Function, Method, Helper };
+module.exports = { Function, Method };

--- a/lib/models/module.js
+++ b/lib/models/module.js
@@ -7,7 +7,6 @@ class Module {
     // Attributes
     this.file = doc.name;
     this.functions = [];
-    this.helpers = [];
     this.variables = [];
 
     // Relationships

--- a/lib/preprocessors/generate-yuidoc-jsonapi.js
+++ b/lib/preprocessors/generate-yuidoc-jsonapi.js
@@ -9,7 +9,6 @@ const Component = require('../models/classes').Component;
 
 const Function = require('../models/functions').Function;
 const Method = require('../models/functions').Method;
-const Helper = require('../models/functions').Helper;
 
 const Variable = require('../models/variables').Variable;
 const Field = require('../models/variables').Field;
@@ -77,9 +76,6 @@ module.exports = function generateYuiDocJsonApi(inputPaths, project) {
 
     } else if (Field.detect(item)) {
       klass.fields.push(new Field(item));
-
-    } else if (Helper.detect(item)) {
-      module.helpers.push(new Helper(item));
 
     } else if (Function.detect(item)) {
       module.functions.push(new Function(item));

--- a/node-tests/fixtures/basic-class/output.json
+++ b/node-tests/fixtures/basic-class/output.json
@@ -9,7 +9,6 @@
       "attributes": {
         "file": "foo",
         "functions": [],
-        "helpers": [],
         "variables": []
       },
       "relationships": {

--- a/node-tests/fixtures/basic-component/output.json
+++ b/node-tests/fixtures/basic-component/output.json
@@ -9,7 +9,6 @@
       "attributes": {
         "file": "components/foo",
         "functions": [],
-        "helpers": [],
         "variables": []
       },
       "relationships": {

--- a/node-tests/fixtures/basic-module/output.json
+++ b/node-tests/fixtures/basic-module/output.json
@@ -79,7 +79,6 @@
             "exportType": "named"
           }
         ],
-        "helpers": [],
         "variables": [
           {
             "name": "baz",

--- a/node-tests/fixtures/helper-module/output.json
+++ b/node-tests/fixtures/helper-module/output.json
@@ -8,8 +8,7 @@
       "id": "helpers/foo",
       "attributes": {
         "file": "helpers/foo",
-        "functions": [],
-        "helpers": [
+        "functions": [
           {
             "name": "helper",
             "file": "helpers/foo",


### PR DESCRIPTION
Helpers turned out to be less unique than originally thought. This PR
removes the simplistic notion of helpers and leaves it to the API docs
themselves to determine what the helper in a module is (class, function,
etc).