### PR TITLE
Fix path normalization for Windows

### DIFF
--- a/lib/preprocessors/generate-yuidoc.js
+++ b/lib/preprocessors/generate-yuidoc.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Y = require('yuidocjs');
+const nodePath = require('path');
 
 const YUIDoc = Y.YUIDoc;
 const DIGESTERS = Y.DocParser.DIGESTERS;
@@ -49,10 +50,15 @@ DIGESTERS.yield = function(tagname, value, target, block) {
 }
 
 function normalizePaths(document, inputPaths) {
-  let inputPath = new RegExp(inputPaths.map(i => `${i}/`).join('|'));
+  let regexStrs = inputPaths
+    .map((str) => nodePath.join(str, '/'))
+    .map((str) => str.replace(/\\/g, '\\\\')) // Ensure Windows-style paths are correctly escaped for the regex
+    .map((str) => str.replace(/\./g, '\\.')); // Ensure eventual dots in path are correctly escaped for the regex
+
+  let inputPath = new RegExp(regexStrs.map((str) => `(${str})`).join('|'));
 
   for (let path in document.files) {
-    let normalizedPath = path.replace(inputPath, '').replace(/(\/index)?\.js/, '');
+    let normalizedPath = normalizePath(path, inputPath);
     let file = document.files[path];
 
     file.name = normalizedPath;
@@ -62,25 +68,32 @@ function normalizePaths(document, inputPaths) {
   }
 
   for (let id in document.classes) {
-    let normalizedId = id.replace(inputPath, '').replace(/(\/index)?\.js/, '');
+    let normalizedId = normalizePath(id, inputPath);
     let klass = document.classes[id];
 
     klass.name = normalizedId;
     klass.shortname = normalizedId;
-    klass.file = klass.file.replace(inputPath, '').replace(/(\/index)?\.js/, '');
+    klass.file = normalizePath(klass.file, inputPath);
 
     document.classes[normalizedId] = klass;
     delete document.classes[id];
   }
 
   for (let item of document.classitems) {
-    item.file = item.file.replace(inputPath, '').replace(/(\/index)?\.js/, '');
-    item.class = item.class.replace(inputPath, '').replace(/(\/index)?\.js/, '');
+    item.file = normalizePath(item.file, inputPath);
+    item.class = normalizePath(item.class, inputPath);
   }
 
   for (let warning of document.warnings) {
-    warning.line = warning.line.replace(inputPath, '');
+    warning.line = normalizePath(warning.line, inputPath);
   }
+}
+
+function normalizePath(filePath, inputPath) {
+  return filePath
+    .replace(inputPath, '') // Remove root of path
+    .replace(/\\/g, '/') // Convert windows-style slashes
+    .replace(/(\/index)?\.js/, ''); // Remove index.js / .js
 }
 
 function isAcceptableWarning(warning) {


### PR DESCRIPTION
This PR fixes path normalization to make this work on Windows.
Currently, this does not work when building on Windows at all, as the paths break everywhere.