### PR TITLE
Fix Windows-compatibility issues

### DIFF
--- a/lib/preprocessors/generate-yuidoc.js
+++ b/lib/preprocessors/generate-yuidoc.js
@@ -48,11 +48,33 @@ DIGESTERS.yield = function(tagname, value, target, block) {
   return paramDigest.call(this, tagname, value, fakeTarget, block);
 }
 
+function normalizePath(path, inputPathRegex) {
+  path = path.replace(inputPathRegex, '');
+
+  // if the path now starts with a slash or backslash, it
+  // must be removed (because it's a relative path now)
+  if (path.startsWith('/') || path.startsWith('\\')) {
+    path = path.slice(1);
+  }
+
+  // we now have a windows or unix style path, but relative
+  // so it's safe to convert to unix style paths at this point
+  // (they will work on windows too)
+  path = path.replace(/\\/g, '/');
+
+  // remove index.js and .js extensions from the end of paths
+  path = path.replace(/(\/index)?\.js/, '');
+
+  return path;
+}
+
 function normalizePaths(document, inputPaths) {
-  let inputPath = new RegExp(inputPaths.map(i => `${i}/`).join('|'));
+  // replace single backslashes with double backslashes (because they would be
+  // regex escape characters), then create a single regex out of all paths.
+  let inputPath = new RegExp(inputPaths.map(i => i.replace(/\\/g, '\\\\')).join('|'));
 
   for (let path in document.files) {
-    let normalizedPath = path.replace(inputPath, '').replace(/(\/index)?\.js/, '');
+    let normalizedPath = normalizePath(path, inputPath);
     let file = document.files[path];
 
     file.name = normalizedPath;
@@ -62,20 +84,20 @@ function normalizePaths(document, inputPaths) {
   }
 
   for (let id in document.classes) {
-    let normalizedId = id.replace(inputPath, '').replace(/(\/index)?\.js/, '');
+    let normalizedId = normalizePath(id, inputPath);
     let klass = document.classes[id];
 
     klass.name = normalizedId;
     klass.shortname = normalizedId;
-    klass.file = klass.file.replace(inputPath, '').replace(/(\/index)?\.js/, '');
+    klass.file = normalizePath(klass.file, inputPath);
 
     document.classes[normalizedId] = klass;
     delete document.classes[id];
   }
 
   for (let item of document.classitems) {
-    item.file = item.file.replace(inputPath, '').replace(/(\/index)?\.js/, '');
-    item.class = item.class.replace(inputPath, '').replace(/(\/index)?\.js/, '');
+    item.file = normalizePath(item.file, inputPath);
+    item.class = normalizePath(item.class, inputPath);
   }
 
   for (let warning of document.warnings) {


### PR DESCRIPTION
When trying to fix https://github.com/ember-learn/ember-cli-addon-docs-yuidoc/issues/4 the 'easy' way, I discovered none of the node-tests pass on a Windows machine. So rather than fixing the very limited issue, I decided to fix the underlying problem which is that the `normalizePaths` function in `generate-yuidoc.js` did not support Windows paths.

The tests now pass on Windows, but I'm not really sure what to do about new tests. I didn't really change intended behavior, and my intuition is that the right thing here is to run the existing tests on Windows as well (say on Appveyor, which is free for open source). Like I said, this would have prevented the issue because they failed on Windows.

Please let me know what you think.