### PR TITLE
TypeScript support

### DIFF
--- a/lib/broccoli/generator.js
+++ b/lib/broccoli/generator.js
@@ -9,7 +9,7 @@ const generateYuiDocJsonApi = require('../preprocessors/generate-yuidoc-jsonapi'
 module.exports = class DocsGenerator extends CachingWriter {
   constructor(inputNodes, options) {
     let defaults = {
-      cacheInclude: [/\.js$/]
+      cacheInclude: [/\.(js|ts)$/],
     };
 
     super(inputNodes, Object.assign(defaults, options));

--- a/lib/preprocessors/generate-yuidoc.js
+++ b/lib/preprocessors/generate-yuidoc.js
@@ -93,7 +93,7 @@ function normalizePath(filePath, inputPath) {
   return filePath
     .replace(inputPath, '') // Remove root of path
     .replace(/\\/g, '/') // Convert windows-style slashes
-    .replace(/(\/index)?\.js/, ''); // Remove index.js / .js
+    .replace(/(\/index)?\.[jt]s/, ''); // Remove index.js / .js
 }
 
 function isAcceptableWarning(warning) {
@@ -102,6 +102,7 @@ function isAcceptableWarning(warning) {
 
 module.exports = function generateYUIDoc(inputPaths, project) {
   let json = new YUIDoc({
+    extension: '.js,.ts',
     quiet: true,
     writeJSON: false,
     paths: inputPaths,


### PR DESCRIPTION
This is apparently enough to get TypeScript support. I think YUIDoc only parses comments, so it doesn't actually care about the difference between JS and TS.