### PR TITLE
[DOCS] Fix component docs example formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ properties:
 * `@argument` which is meant to represent an argument passed into the
 component
 
-```js
+~~~js
 /**
   A foo-bar component. Usage:
 
@@ -119,7 +119,7 @@ export default Ember.Component.extend({
   */
   baz: -1
 });
-```
+~~~
 
 ### Documenting Modules
 


### PR DESCRIPTION
This fixes the formatting of the "Component Documentation" example in the readme. It was previously being mangled due to the nested code block in the example.