### PR TITLE
[BUGFIX] Fix support for decorators

### DIFF
--- a/lib/preprocessors/generate-yuidoc.js
+++ b/lib/preprocessors/generate-yuidoc.js
@@ -49,6 +49,35 @@ DIGESTERS.yield = function(tagname, value, target, block) {
   return paramDigest.call(this, tagname, value, fakeTarget, block);
 }
 
+const originalHandleComment = Y.DocParser.prototype.handlecomment;
+
+const AT_PLACEHOLDER = '---AT-PLACEHOLDER---';
+const AT_PLACEHOLDER_REGEX = new RegExp(AT_PLACEHOLDER, 'g');
+
+// Patch YuiDoc parser to support `@`
+Y.DocParser.prototype.handlecomment = function(comment, file, line) {
+  let lines = comment.split(/\r\n|\n/);
+
+  let inMarkdownBlock = false;
+
+  let newLines = lines.map((line) => {
+    if (line.match(/^(\s*\*)?\s*```/)) {
+      inMarkdownBlock = !inMarkdownBlock;
+    }
+
+    return inMarkdownBlock ? line.replace(/@/g, AT_PLACEHOLDER) : line;
+  });
+
+  let ret = originalHandleComment.call(this, newLines.join('\n'), file, line);
+  let description = ret.find(t => t.tag === 'description');
+
+  if (description) {
+    description.value = description.value.replace(AT_PLACEHOLDER_REGEX, '@');
+  }
+
+  return ret;
+}
+
 function normalizePaths(document, inputPaths) {
   let regexStrs = inputPaths
     .map((str) => nodePath.join(str, '/'))


### PR DESCRIPTION
Allow using decorators and glimmer components:
```
<Avatar
  @name={{this.name}}
  @image={{this.image}}
/>
```

Closes #11.

Also see https://github.com/cibernox/ember-cli-yuidoc/pull/52